### PR TITLE
Fixed usage calculation return null when smart meter only have 1 reading

### DIFF
--- a/src/usage/usage.js
+++ b/src/usage/usage.js
@@ -13,7 +13,7 @@ const timeElapsedInHours = (readings) => {
 };
 
 const usage = (readings) => {
-    return average(readings) / timeElapsedInHours(readings);
+    return average(readings) / (timeElapsedInHours(readings) || 1);
 };
 
 const usageCost = (readings, rate) => {


### PR DESCRIPTION
In `reading.data.js` line 6, reading length can be randomly generated from 1 - 20, but if a smart meter only has 1 reading, function `timeElapsedInHours` in `usage.js` would return the result of 0, and then when the average reading is divided by 0, an `Infinity` gets returned, eventually `usageCost` for each price plan gets null.